### PR TITLE
feat(skills): add /spec-verify — visual browser check for frontend specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: grouped by version. New entries go under `## [Unreleased]` and are moved
 
 ## [Unreleased]
 
+- **Spec 625**: `/spec-verify` skill — optional visual browser check for frontend specs via MCP Playwright; auto dev-server lifecycle, file-pattern detection (.tsx/.vue/.css/.scss/.twig etc.), PASS/CONCERNS report
 - **Spec 619**: Claude Code 2.1.89+ Alignment — tdd-checker absolute path fix, permission-denied retry logic, TaskCreated hook, disableSkillShellExecution warning
 
 ## [v2.0.8] — 2026-04-03

--- a/specs/completed/625-spec-verify-browser-check.md
+++ b/specs/completed/625-spec-verify-browser-check.md
@@ -1,0 +1,33 @@
+# Spec: spec-verify skill — optional browser check for frontend specs
+
+> **Spec ID**: 625 | **Created**: 2026-04-06 | **Status**: completed | **Complexity**: low | **Branch**: —
+
+## Goal
+Add a standalone `/spec-verify NNN` skill that visually verifies frontend changes via MCP Playwright after `spec-run`.
+
+## Context
+`spec-review` checks code quality and acceptance criteria but never opens a browser. CSS bugs, layout regressions, and broken states go unnoticed until manual testing. The challenge verdict was SIMPLIFY: no integration into `spec-run`, just a standalone optional skill the user calls explicitly. Relies on MCP Playwright being configured.
+
+### Verified Assumptions
+- MCP Playwright available at runtime — Evidence: session MCP tools `mcp__playwright__*` | Confidence: High | If Wrong: skill reports "MCP Playwright not available" and exits
+- Dev-server command in package.json — Evidence: standard npm convention | Confidence: Medium | If Wrong: skill asks user for start command
+- Auto-discovered by template map — Evidence: `build_template_map()` in `lib/core.sh` | Confidence: High | If Wrong: add explicit entry
+
+## Steps
+- [x] Step 1: Create `templates/skills/spec-verify/SKILL.template.md` — reads spec, detects frontend files (.tsx/.jsx/.vue/.svelte/.css/.scss/.html/.twig), asks user for route, checks if dev server responds (curl localhost); if not: reads package.json for start command, starts it, waits for ready, runs verify, stops server after; navigates with MCP Playwright, takes screenshot, runs basic interaction checks, reports PASS/CONCERNS
+- [x] Step 2: Add workflow hint row in `templates/claude/rules/workflow.md` — after `/spec-run` suggest `/spec-verify NNN` for frontend specs
+- [x] Step 3: Verify skill is discoverable via `build_template_map()` and has correct frontmatter
+
+## Acceptance Criteria
+- [ ] "`ls templates/skills/spec-verify/SKILL.template.md` returns the file"
+- [ ] "Skill frontmatter has name, description, and model fields"
+- [ ] "`grep 'spec-verify' templates/claude/rules/workflow.md` shows the new hint row"
+
+## Files to Modify
+- `templates/skills/spec-verify/SKILL.template.md` - new skill (create)
+- `templates/claude/rules/workflow.md` - add hint row
+
+## Out of Scope
+- Integration into spec-run pipeline (standalone only)
+- Playwright installation handling (global MCP setup assumed)
+- Visual regression testing / screenshot diffing

--- a/templates/claude/rules/workflow.md
+++ b/templates/claude/rules/workflow.md
@@ -14,6 +14,7 @@ After completing work, suggest the logical next skill. Keep hints to one line.
 | Multi-file changes (3+ files, incl. config/rules) | `/spec` — erst planen, dann bauen |
 | Session start + `.continue-here.md` exists | `/resume` — State wiederherstellen |
 | Session >30 tool calls | `/reflect` — Learnings sichern, dann `/pause` |
+| `/spec-run NNN` done (frontend files) | `/spec-verify NNN` — visueller Browser-Check |
 | Build failure | `/build-fix` — iterativ fixen |
 | Pre-release | `/release` — Version bump, CHANGELOG, Tag |
 

--- a/templates/skills/spec-verify/SKILL.template.md
+++ b/templates/skills/spec-verify/SKILL.template.md
@@ -1,0 +1,79 @@
+---
+name: ais:spec-verify
+description: "Visual browser verification for frontend specs via MCP Playwright. Triggers: /spec-verify NNN, 'verify spec NNN in browser', 'browser check spec NNN', 'visually verify spec NNN'."
+model: sonnet
+---
+
+Runs a visual browser check for spec $ARGUMENTS against a live dev server using MCP Playwright.
+
+## Process
+
+### 1. Find the spec
+If `$ARGUMENTS` is a number, open `specs/NNN-*.md`. If empty, list specs with status `completed` or `in-review` and ask.
+
+### 2. Detect frontend files
+Scan `Files to Modify` section of the spec. Check if any file matches:
+`.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.html`, `.twig`
+
+If no frontend files found: report "No frontend files in this spec — /spec-verify not applicable." and stop.
+
+### 3. Ask for route
+`AskUserQuestion`: "Which route should be verified? (e.g. /dashboard, /products/123)"
+Use the answer as the target URL path.
+
+### 4. Dev server check
+Run: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` (try common ports: 3000, 4000, 8080, 5173)
+
+**Server already running**: proceed to Step 5.
+
+**Server not running**:
+1. Read `package.json` → find start/dev command (prefer `dev`, then `start`, then `serve`)
+2. Start server: `! npm run dev > /tmp/spec-verify-server.log 2>&1 & echo $! > /tmp/spec-verify-server.pid`
+3. Wait for server: poll `curl` every 2s, max 30s. If no response after 30s → kill via PID file, report failure, stop.
+4. Note PID file path for cleanup in Step 7.
+
+### 5. Navigate and verify
+Using MCP Playwright tools:
+
+1. `browser_navigate` → `http://localhost:<port><route>`
+2. `browser_snapshot` → capture accessibility snapshot
+3. `browser_take_screenshot` → visual capture
+4. Check for: console errors (`browser_console_messages`), visible error states, broken layout indicators (overflow, 0-height containers)
+5. If the spec mentions interactive elements (buttons, forms, modals): perform 1-2 key interactions via `browser_click` or `browser_fill_form`, take another screenshot
+
+### 6. Report result
+
+**PASS** — No console errors, page renders, key elements visible:
+```
+spec-verify NNN: PASS
+Route: /example
+Screenshots: taken
+Interactions: [what was tested]
+No console errors detected.
+```
+
+**CONCERNS** — Issues found:
+```
+spec-verify NNN: CONCERNS
+Route: /example
+Issues:
+  - Console error: [message]
+  - Element [selector] not visible
+  - [other finding]
+Screenshots: taken
+Next: If this is a CMS project (Shopware, Shopify, Storyblok etc.) — check MCP server for content/config issues: missing fields, unpublished entries, wrong slugs.
+```
+
+### 7. Cleanup
+If server was started by this skill: `! kill $(cat /tmp/spec-verify-server.pid) 2>/dev/null && rm -f /tmp/spec-verify-server.pid /tmp/spec-verify-server.log`
+
+## Rules
+- MCP Playwright must be configured globally — if tools unavailable, report and stop.
+- Never commit or modify files.
+- Port detection: try 3000, 5173, 4000, 8080 in that order.
+- Screenshot filenames are not saved to disk — they appear inline in the chat only.
+
+## Next Step
+
+- PASS: `> ⚡ Naechster Schritt: /commit — Changes committen`
+- CONCERNS: `> 🔧 Naechster Schritt: Issues fixen, dann /spec-verify NNN erneut`


### PR DESCRIPTION
## Summary
- New standalone `/spec-verify NNN` skill for visual frontend verification via MCP Playwright
- Auto dev-server lifecycle: detects running server or starts/stops it via PID file
- Frontend file detection: `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.html`, `.twig`
- Reports PASS/CONCERNS with CMS hint (Shopware, Shopify, Storyblok) for content/config issues
- Workflow hint added to `rules/workflow.md` after `/spec-run`

## Test plan
- [ ] Run `/spec-verify` on a spec with frontend files — should ask for route and open browser
- [ ] Run `/spec-verify` on a spec with no frontend files — should skip gracefully
- [ ] Run with dev server stopped — should auto-start and stop after verify
- [ ] Verify workflow hint appears in Claude's routing suggestions after spec-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)