### PR TITLE
Add corpus size check and improve skill documentation

### DIFF
--- a/.claude/scripts/doctor.sh
+++ b/.claude/scripts/doctor.sh
@@ -310,6 +310,18 @@ else
   add_row "$WARN" "Specs"               "No specs/ directory"
 fi
 
+# 16. Corpus size
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+  corpus_count="$(git ls-files 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$corpus_count" -gt 500 ]; then
+    add_row "$WARN" "Corpus size" "${corpus_count} tracked files — /analyze and /context-refresh will be expensive"
+  elif [ "$corpus_count" -lt 5 ]; then
+    add_row "$WARN" "Corpus size" "${corpus_count} tracked files — too small for context generation to add value"
+  else
+    add_row "$PASS" "Corpus size" "${corpus_count} tracked files"
+  fi
+fi
+
 # Output table
 echo "# Doctor Report"
 echo ""

--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -36,7 +36,17 @@ Agent prompts: `@references/agents-batch-mode.md`
 ## Hotspots
 ## Risks
 ## Recommendations (3-5 actionable)
+## Suggested Questions (3-5 investigation threads)
 ```
+
+After Recommendations, include 3–5 follow-up questions targeting structural weaknesses found during analysis. Tailor questions to what was actually observed:
+- **Hub overload**: "Why is `<file>` the most-imported module — is an abstraction boundary missing?"
+- **Isolated module**: "Who is the only consumer of `<module>` — could it be inlined or removed?"
+- **Fragile dependency**: "What breaks if `<file>` changes — are callers decoupled enough?"
+- **Circular dependency** (if found): "Can the circular dependency between `<A>` and `<B>` be broken?"
+- **Unclear ownership**: "Which domain or team owns `<component>` — is responsibility documented?"
+
+Only include questions for patterns actually found. Skip any that are not relevant to this codebase.
 
 ### 4. Persist artifacts
 

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -14,6 +14,8 @@ Curious, open-ended exploration of a problem or codebase. Reads everything, writ
 - Bash (read-only commands: `ls`, `cat`, `find`, `wc`, `git log`, `git diff`, `git show`)
 - WebFetch, WebSearch
 
+> **Library/API docs**: prefer the Context7 MCP tool (`use context7`) for official documentation — it's more precise and token-efficient than WebSearch. Fall back to WebFetch if Context7 is unavailable.
+
 ## Forbidden Tools
 
 NEVER use: Write, Edit, NotebookEdit. This skill is strictly read-only.

--- a/.claude/skills/techdebt/SKILL.md
+++ b/.claude/skills/techdebt/SKILL.md
@@ -16,7 +16,16 @@ Scans recently changed files for tech debt and fixes safe wins. Use at end of se
    - Unused imports
    - TODO/FIXME/HACK comments that could be resolved now
    - Inconsistent patterns compared to the rest of the codebase
-3. **Report findings** grouped by category with file paths and line numbers.
+3. **Report findings** grouped by category with confidence levels, file paths, and line numbers. Use this format:
+   ```
+   [HIGH] Dead export `fooBar` in api/utils.ts:45 — 0 callers found
+   [MED]  Duplicated block (8 lines) in auth.ts:23 and middleware.ts:91
+   [LOW]  TODO in config.ts:12 — unresolved, low risk
+   ```
+   Confidence levels:
+   - **[HIGH]**: Verifiable via static analysis (unused exports with 0 grep hits, exact duplicate literals)
+   - **[MED]**: Likely but may have dynamic or test-only usage — verify before removing
+   - **[LOW]**: Pattern heuristic (old TODOs, style inconsistencies) — report only, do not auto-fix
 4. **Fix clear wins only**: Remove unused imports, delete dead exports, consolidate obvious duplicates. Leave anything ambiguous for the user.
 
 5. **Verify fixes**: Spawn `verify-app` via Agent tool (`model: haiku`) with the prompt:

--- a/templates/scripts/doctor.sh
+++ b/templates/scripts/doctor.sh
@@ -310,6 +310,18 @@ else
   add_row "$WARN" "Specs"               "No specs/ directory"
 fi
 
+# 16. Corpus size
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+  corpus_count="$(git ls-files 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$corpus_count" -gt 500 ]; then
+    add_row "$WARN" "Corpus size" "${corpus_count} tracked files — /analyze and /context-refresh will be expensive"
+  elif [ "$corpus_count" -lt 5 ]; then
+    add_row "$WARN" "Corpus size" "${corpus_count} tracked files — too small for context generation to add value"
+  else
+    add_row "$PASS" "Corpus size" "${corpus_count} tracked files"
+  fi
+fi
+
 # Output table
 echo "# Doctor Report"
 echo ""

--- a/templates/skills/analyze/SKILL.template.md
+++ b/templates/skills/analyze/SKILL.template.md
@@ -41,7 +41,17 @@ Agent prompts: `@references/agents-batch-mode.md`
 ## Hotspots
 ## Risks
 ## Recommendations (3-5 actionable)
+## Suggested Questions (3-5 investigation threads)
 ```
+
+After Recommendations, include 3–5 follow-up questions targeting structural weaknesses found during analysis. Tailor questions to what was actually observed:
+- **Hub overload**: "Why is `<file>` the most-imported module — is an abstraction boundary missing?"
+- **Isolated module**: "Who is the only consumer of `<module>` — could it be inlined or removed?"
+- **Fragile dependency**: "What breaks if `<file>` changes — are callers decoupled enough?"
+- **Circular dependency** (if found): "Can the circular dependency between `<A>` and `<B>` be broken?"
+- **Unclear ownership**: "Which domain or team owns `<component>` — is responsibility documented?"
+
+Only include questions for patterns actually found. Skip any that are not relevant to this codebase.
 
 ### 4. Persist artifacts
 

--- a/templates/skills/explore/SKILL.template.md
+++ b/templates/skills/explore/SKILL.template.md
@@ -22,6 +22,8 @@ Curious, open-ended exploration of a problem or codebase. Reads everything, writ
 - Bash (read-only commands: `ls`, `cat`, `find`, `wc`, `git log`, `git diff`, `git show`)
 - WebFetch, WebSearch
 
+> **Library/API docs**: prefer the Context7 MCP tool (`use context7`) for official documentation — it's more precise and token-efficient than WebSearch. Fall back to WebFetch if Context7 is unavailable.
+
 ## Forbidden Tools
 
 NEVER use: Write, Edit, NotebookEdit. This skill is strictly read-only.

--- a/templates/skills/techdebt/SKILL.template.md
+++ b/templates/skills/techdebt/SKILL.template.md
@@ -23,7 +23,16 @@ Scans recently changed files for tech debt and fixes safe wins. Use at end of se
    - Unused imports
    - TODO/FIXME/HACK comments that could be resolved now
    - Inconsistent patterns compared to the rest of the codebase
-3. **Report findings** grouped by category with file paths and line numbers.
+3. **Report findings** grouped by category with confidence levels, file paths, and line numbers. Use this format:
+   ```
+   [HIGH] Dead export `fooBar` in api/utils.ts:45 — 0 callers found
+   [MED]  Duplicated block (8 lines) in auth.ts:23 and middleware.ts:91
+   [LOW]  TODO in config.ts:12 — unresolved, low risk
+   ```
+   Confidence levels:
+   - **[HIGH]**: Verifiable via static analysis (unused exports with 0 grep hits, exact duplicate literals)
+   - **[MED]**: Likely but may have dynamic or test-only usage — verify before removing
+   - **[LOW]**: Pattern heuristic (old TODOs, style inconsistencies) — report only, do not auto-fix
 4. **Fix clear wins only**: Remove unused imports, delete dead exports, consolidate obvious duplicates. Leave anything ambiguous for the user.
 
 5. **Verify fixes**: Spawn `verify-app` via Agent tool (`model: haiku`) with the prompt:


### PR DESCRIPTION
## Summary
This PR enhances the doctor diagnostic script with a corpus size check and improves documentation across multiple skills to provide clearer guidance on output formats, confidence levels, and tool usage.

## Key Changes

### Doctor Script Enhancement
- **Added corpus size check** (section 16): Validates the number of tracked files in the git repository
  - Warns if corpus exceeds 500 files (expensive for `/analyze` and `/context-refresh`)
  - Warns if corpus is below 5 files (too small for effective context generation)
  - Passes if corpus is in the optimal 5-500 file range
  - Applied to both `.claude/scripts/doctor.sh` and `templates/scripts/doctor.sh`

### Skill Documentation Improvements

**techdebt skill**:
- Added structured reporting format with confidence levels `[HIGH]`, `[MED]`, `[LOW]`
- Defined clear criteria for each confidence level to guide finding verification
- Clarified which findings should be auto-fixed vs. reported for manual review

**analyze skill**:
- Added "Suggested Questions" section to the output template
- Provided concrete examples of investigation threads targeting structural weaknesses (hub overload, isolated modules, fragile dependencies, circular dependencies, unclear ownership)
- Emphasized tailoring questions to patterns actually found in the codebase

**explore skill**:
- Added guidance to prefer Context7 MCP tool for library/API documentation over WebSearch
- Noted that Context7 is more precise and token-efficient for official documentation

All changes applied to both source files and their corresponding templates for consistency.

https://claude.ai/code/session_01JedoSwcsnjKncnCvnRcxkE