### PR TITLE
Fix SDD workflow parsing bugs and threshold inconsistencies

### DIFF
--- a/.claude/plans/quiet-strolling-kahn.md
+++ b/.claude/plans/quiet-strolling-kahn.md
@@ -1,0 +1,144 @@
+# Plan: SDD Workflow Audit & Fixes
+
+## Context
+
+Review of the spec-driven development (SDD) pipeline revealed **one confirmed parse bug**, **two threshold inconsistencies**, and **a workflow routing gap**. Additionally, several agents referenced in SDD skills do not exist as `.claude/agents/` files, which causes silent fallback to built-in agent behavior.
+
+---
+
+## Findings
+
+### 1. Bug — `spec-review-prep.sh`: wrong grep patterns for STATUS and SPEC_BRANCH
+
+**File**: `.claude/scripts/spec-review-prep.sh`
+
+The spec metadata line format (confirmed in `specs/606-spec-stop-guard-hook.md:3`) is:
+```
+> **Spec ID**: 606 | **Created**: ... | **Status**: completed | **Complexity**: medium | **Branch**: main
+```
+
+But the script uses:
+```bash
+# Line 60-62 — SPEC_BRANCH
+grep -E '^\*\*Branch\*\*' "$SPEC_FILE"   # ← won't match (line starts with "> ")
+
+# Line 133-135 — STATUS
+grep -E '^\*\*Status\*\*' "$SPEC_FILE"   # ← won't match
+```
+
+Result: `SPEC_BRANCH` is always empty → always falls back to working-tree diff instead of the branch diff. `STATUS` is always `"unknown"`.
+
+Compare: `spec-stop-guard.sh` correctly uses `grep -q '^\> .*Status.*in-progress'`. `spec-validate-prep.sh` uses Python `re.search(r'\*\*Status\*\*:\s*([^|\n]+)', ...)` which is unanchored.
+
+**Fix — SPEC_BRANCH** (lines 60–62, replace block):
+```bash
+SPEC_BRANCH="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | grep -oE '\*\*Branch\*\*: `[^`]+`' \
+  | tr -d '`' \
+  | sed 's/\*\*Branch\*\*: //' || true)"
+```
+
+**Fix — STATUS** (lines 133–135, replace block):
+```bash
+STATUS="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | sed -n 's/.*\*\*Status\*\*: \([^|]*\).*/\1/p' \
+  | tr -d ' ' || echo "unknown")"
+```
+
+---
+
+### 2. Inconsistency — Step count warning threshold
+
+**File**: `.claude/scripts/spec-validate-prep.sh`, line 133
+
+The script warns at `> 10` steps. But `spec/SKILL.md` (line 88, 133) specifies:
+- max 8 steps (hard constraint)
+- auto-split triggers at `> 8 steps`
+
+**Fix**: Change threshold from `$STEP_COUNT -gt 10` to `$STEP_COUNT -gt 8`.
+
+---
+
+### 3. Inconsistency — Workflow routing table: `/spec` hint is causally backwards
+
+**File**: `.claude/rules/workflow.md`
+
+Current row:
+```
+| Multi-file changes (3+ files, incl. config/rules) | `/spec` — erst planen, dann bauen |
+```
+
+This implies: *you've already made changes* → then create a spec. That inverts the spec-first principle. The hint should fire **before** implementation, not after.
+
+**Fix**: Reword the trigger condition:
+```
+| Planning a multi-file change (3+ files, new dep, or arch change) | `/spec` — erst planen, dann bauen |
+```
+
+---
+
+### 4. Gap — Missing `/spec-validate` hint after `/spec`
+
+**File**: `.claude/rules/workflow.md`
+
+The routing table has no entry for:
+> After `/spec` is written → validate before starting work
+
+The `spec/SKILL.md` already ends with "run `/spec-validate NNN` to score it before execution", but the workflow routing table doesn't reinforce this.
+
+**Fix**: Add row to table:
+```
+| Spec created (Status: draft) | `/spec-validate NNN` — Qualität prüfen vor Umsetzung |
+```
+
+---
+
+### 5. Info — Referenced agents that don't exist
+
+The following agents are referenced in SDD skills but have **no file** in `.claude/agents/`:
+
+| Agent | Referenced in |
+|-------|---------------|
+| `staff-reviewer` | spec-work, spec-review |
+| `performance-reviewer` | spec-work, spec-review |
+| `code-architect` | spec-work |
+| `verify-app` | spec-work |
+| `test-generator` | spec-work |
+| `frontend-developer` | spec-work |
+| `backend-developer` | spec-work |
+
+Only `code-reviewer` and `security-reviewer` exist. When skills spawn missing agents, Claude Code falls back to a generic built-in agent — no crash, but no specialization.
+
+This is **not a blocking bug** (the skills already guard with "Only if agent exists in `.claude/agents/`" for the specialist agents). No change needed for this session — document as follow-up.
+
+---
+
+## Changes
+
+```mermaid
+flowchart LR
+    A[spec-review-prep.sh\nSTATUS + SPEC_BRANCH\n2 regex fixes] --> G{git branch diff\nnow works}
+    B[spec-validate-prep.sh\nstep warning >8] --> H{threshold matches\nSKILL.md}
+    C[workflow.md\ntrigger wording] --> I{spec-first\ncausality correct}
+    C --> J[add spec-validate\nhint row]
+```
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `.claude/scripts/spec-review-prep.sh` | Fix SPEC_BRANCH (lines 60-62) and STATUS (lines 133-135) extraction |
+| `.claude/scripts/spec-validate-prep.sh` | Change step warning threshold from `>10` to `>8` (line 133) |
+| `.claude/rules/workflow.md` | Reword `/spec` trigger; add `/spec-validate` hint row |
+
+---
+
+## Verification
+
+After implementation:
+1. Create a test spec file locally with a known branch name in the metadata row, run `bash .claude/scripts/spec-review-prep.sh <spec-number>`, verify SPEC_BRANCH and STATUS are populated correctly.
+2. Check `bash -n .claude/scripts/spec-review-prep.sh` and `bash -n .claude/scripts/spec-validate-prep.sh` for syntax errors.
+3. Run `bash .claude/scripts/quality-gate.sh` to confirm no shellcheck failures.
+4. Verify workflow.md reads cleanly: the `/spec` row triggers before changes, `/spec-validate` row appears after it.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -11,7 +11,8 @@ After completing work, suggest the logical next skill. Keep hints to one line.
 | `/review` passes | `/commit` — Stagen + committen |
 | `/commit` done | `/pr` auf Feature-Branches, oder `/release` auf `main` / `master` |
 | Bug investigation | `/debug` falls noch nicht geladen |
-| Multi-file changes (3+ files, incl. config/rules) | `/spec` — erst planen, dann bauen |
+| Planning a multi-file change (3+ files, new dep, or arch change) | `/spec` — erst planen, dann bauen |
+| Spec erstellt (Status: draft) | `/spec-validate NNN` — Qualität prüfen vor Umsetzung |
 | Spec erstellt oder abgeschlossen | `/clear` — Session leeren, Kontext-Bleed vermeiden |
 | Session >30 tool calls | `/reflect` — Learnings sichern, dann `/clear` |
 | Build failure | `/build-fix` — iterativ fixen |

--- a/.claude/scripts/spec-review-prep.sh
+++ b/.claude/scripts/spec-review-prep.sh
@@ -57,8 +57,11 @@ printf "Spec: %s (%s)\n" "$SPEC_FILE" "$SPEC_TITLE"
 # 1. Extract branch from spec header
 # ---------------------------------------------------------------------------
 section "BRANCH"
-SPEC_BRANCH="$(grep -E '^\*\*Branch\*\*' "$SPEC_FILE" 2>/dev/null \
-  | grep -oE '`[^`]+`' | tr -d '`' | head -1 || true)"
+SPEC_BRANCH="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | grep -oE '\*\*Branch\*\*: `[^`]+`' \
+  | tr -d '`' \
+  | sed 's/\*\*Branch\*\*: //' || true)"
 
 if [[ -n "$SPEC_BRANCH" ]]; then
   printf "Spec branch: %s\n" "$SPEC_BRANCH"
@@ -130,8 +133,11 @@ fi
 # 5. Spec status + acceptance criteria summary
 # ---------------------------------------------------------------------------
 section "SPEC STATUS"
-STATUS="$(grep -E '^\*\*Status\*\*' "$SPEC_FILE" 2>/dev/null \
-  | sed 's/.*: *//' | head -1 || echo "unknown")"
+STATUS="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | sed -n 's/.*\*\*Status\*\*: \([^|]*\).*/\1/p' \
+  | tr -d ' ' || echo "unknown")"
+STATUS="${STATUS:-unknown}"
 printf "Status: %s\n" "$STATUS"
 
 AC_TOTAL="$(awk '/^## Acceptance Criteria/{f=1;next} f&&/^## /{exit} f&&/^\s*-\s*\[/{c++} END{print c+0}' "$SPEC_FILE")"

--- a/.claude/scripts/spec-validate-prep.sh
+++ b/.claude/scripts/spec-validate-prep.sh
@@ -131,8 +131,8 @@ printf "Remaining steps: %s\n" "$STEP_TODO"
 
 if [ "$STEP_COUNT" -eq 0 ]; then
   printf "\n> WARNING: No steps found. Steps section may be empty or not following checkbox format.\n"
-elif [ "$STEP_COUNT" -gt 10 ]; then
-  printf "\n> WARNING: %s steps — consider splitting this spec (>10 steps is a complexity smell).\n" "$STEP_COUNT"
+elif [ "$STEP_COUNT" -gt 8 ]; then
+  printf "\n> WARNING: %s steps — consider splitting this spec (max 8 steps per spec/SKILL.md).\n" "$STEP_COUNT"
 fi
 
 # ---------------------------------------------------------------------------

--- a/templates/scripts/spec-review-prep.sh
+++ b/templates/scripts/spec-review-prep.sh
@@ -57,8 +57,11 @@ printf "Spec: %s (%s)\n" "$SPEC_FILE" "$SPEC_TITLE"
 # 1. Extract branch from spec header
 # ---------------------------------------------------------------------------
 section "BRANCH"
-SPEC_BRANCH="$(grep -E '^\*\*Branch\*\*' "$SPEC_FILE" 2>/dev/null \
-  | grep -oE '`[^`]+`' | tr -d '`' | head -1 || true)"
+SPEC_BRANCH="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | grep -oE '\*\*Branch\*\*: `[^`]+`' \
+  | tr -d '`' \
+  | sed 's/\*\*Branch\*\*: //' || true)"
 
 if [[ -n "$SPEC_BRANCH" ]]; then
   printf "Spec branch: %s\n" "$SPEC_BRANCH"
@@ -130,8 +133,11 @@ fi
 # 5. Spec status + acceptance criteria summary
 # ---------------------------------------------------------------------------
 section "SPEC STATUS"
-STATUS="$(grep -E '^\*\*Status\*\*' "$SPEC_FILE" 2>/dev/null \
-  | sed 's/.*: *//' | head -1 || echo "unknown")"
+STATUS="$(grep -E '^\>' "$SPEC_FILE" 2>/dev/null \
+  | head -1 \
+  | sed -n 's/.*\*\*Status\*\*: \([^|]*\).*/\1/p' \
+  | tr -d ' ' || echo "unknown")"
+STATUS="${STATUS:-unknown}"
 printf "Status: %s\n" "$STATUS"
 
 AC_TOTAL="$(awk '/^## Acceptance Criteria/{f=1;next} f&&/^## /{exit} f&&/^\s*-\s*\[/{c++} END{print c+0}' "$SPEC_FILE")"

--- a/templates/scripts/spec-validate-prep.sh
+++ b/templates/scripts/spec-validate-prep.sh
@@ -131,8 +131,8 @@ printf "Remaining steps: %s\n" "$STEP_TODO"
 
 if [ "$STEP_COUNT" -eq 0 ]; then
   printf "\n> WARNING: No steps found. Steps section may be empty or not following checkbox format.\n"
-elif [ "$STEP_COUNT" -gt 10 ]; then
-  printf "\n> WARNING: %s steps — consider splitting this spec (>10 steps is a complexity smell).\n" "$STEP_COUNT"
+elif [ "$STEP_COUNT" -gt 8 ]; then
+  printf "\n> WARNING: %s steps — consider splitting this spec (max 8 steps per spec/SKILL.md).\n" "$STEP_COUNT"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes critical parsing bugs in the spec-driven development (SDD) workflow pipeline and aligns validation thresholds with documented constraints. The changes ensure spec metadata is correctly extracted and workflow routing properly guides users through the spec-first development process.

## Key Changes

- **Fixed spec metadata extraction in `spec-review-prep.sh`**
  - Corrected `SPEC_BRANCH` extraction to match the actual spec header format (lines starting with `> `) instead of looking for lines starting with `**Branch**`
  - Fixed `STATUS` extraction using proper sed pattern to parse the pipe-delimited metadata row
  - These bugs caused `SPEC_BRANCH` to always be empty (falling back to working-tree diff) and `STATUS` to always be "unknown"

- **Aligned step count warning threshold in `spec-validate-prep.sh`**
  - Changed warning threshold from `>10` steps to `>8` steps to match the documented maximum in `spec/SKILL.md`
  - Updated warning message to reference the spec constraint rather than a vague "complexity smell"

- **Improved workflow routing in `workflow.md`**
  - Reworded `/spec` trigger condition from "Multi-file changes (3+ files...)" to "Planning a multi-file change..." to correctly reflect the spec-first causality (plan before implementation, not after)
  - Added new workflow hint row for `/spec-validate` to reinforce validation step after spec creation

## Implementation Details

- Both script fixes use anchored grep patterns (`^\>`) to match the actual spec metadata line format
- The `SPEC_BRANCH` extraction now properly handles backtick-wrapped branch names
- The `STATUS` extraction uses sed to isolate the status value between `**Status**:` and the next pipe delimiter
- Changes applied to both `.claude/scripts/` and `templates/scripts/` for consistency
- All modifications maintain backward compatibility and add defensive fallbacks (`|| true`, `|| echo "unknown"`)

https://claude.ai/code/session_01ERKJSVV4yUh7A8KPrWBQMB